### PR TITLE
Add Take Profit and Stop Loss methods to Perpetual Position Class

### DIFF
--- a/src/Api/Perpetual/Position.php
+++ b/src/Api/Perpetual/Position.php
@@ -41,4 +41,24 @@ class Position extends Request
         $this->data=$data;
         return $this->exec();
     }
+
+    /**
+     *POST https://api.coinex.com/perpetual/v1/position/take_profit
+     * */
+    public function postTakeProfit(array $data=[]){
+        $this->type='POST';
+        $this->path='/position/take_profit';
+        $this->data=$data;
+        return $this->exec();
+    }
+
+    /**
+     *POST https://api.coinex.com/perpetual/v1/position/stop_loss
+     * */
+    public function postStopLoss(array $data=[]){
+        $this->type='POST';
+        $this->path='/position/stop_loss';
+        $this->data=$data;
+        return $this->exec();
+    }
 }


### PR DESCRIPTION
This commit adds **Take Profit** and **Stop Loss** methods to the **Perpetual Position Class** in the CoinEx API.

The **postTakeProfit** method allows users to easily send Take Profit orders, while the **postStopLoss** method is designed to submit Stop Loss orders.

With these changes, users will have better control over managing their positions in perpetual markets.

Please review the changes and share any feedback.

Thank you!